### PR TITLE
Fix REM comments

### DIFF
--- a/grammars/basic.cson
+++ b/grammars/basic.cson
@@ -26,7 +26,7 @@ patterns: [
   }
   {
     # comment
-    match: '(?i:\bREM\b.*|^\'.*| \'.*)'
+    match: '(?i:\\bREM\\b.*|^\'.*| \'.*)'
     name: 'comment.line.basic'
   }
   {


### PR DESCRIPTION
This should fix the higlighting of REM comments, since it's not working at the moment and all other CSON strings in this file use the double-backslash to escape `\`.

```BASIC
10 REM foo and bar
```